### PR TITLE
Don't call boot.sh from run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,4 +11,6 @@ if [ ! -f "${AUTH_FILE}" ]; then
   exit 1
 fi
 
-exec ./boot.sh
+cat < $APP_ROOT/nginx/logs/access.log &
+(>&2 cat) < $APP_ROOT/nginx/logs/error.log &
+exec $APP_ROOT/nginx/sbin/nginx -p $APP_ROOT/nginx -c $APP_ROOT/nginx/conf/nginx.conf


### PR DESCRIPTION
Cloudfoundry have stopped using boot.sh in their static build pack. We
were calling it from run.sh, which was invoked as a custom start command
from the manifest. This broke things.

I've added the new default start command for the static build pack to
the end of the run.sh script.